### PR TITLE
P3826: Copy-paste error in [exec.stopped.opt] paragraph 4

### DIFF
--- a/P3826/P3826.md
+++ b/P3826/P3826.md
@@ -2197,10 +2197,14 @@ subsection as follows:]{.ednote}
 > 3. The exposition-only class template [&hellip; as before &hellip;]{.blue}
 >
 > 4. Let `sndr` and `env` be subexpressions such that `Sndr` is `decltype((sndr))` and `Env`
->    is `decltype((env))`. If ```@_`sender-for`_@<Sndr, stopped_as_error_t>``` is `false`,
+>    is `decltype((env))`. If ```@_`sender-for`_@<Sndr, stopped_as_optional_t>``` is `false`
 >    then the expression
->    ```stopped_as_error.transform_sender(@[`set_value,`]{.add}@ sndr, env)``` is ill-formed;
->    otherwise, it is equivalent to: [&hellip; as before &hellip;]{.blue}
+>    ```stopped_as_optional.transform_sender(@[`set_value, `]{.add}@ sndr, env)``` is
+>    ill-formed; otherwise, if ```sender_in<@_`child-type`_@<Sndr>, @_`FWD-ENV-T`_@(Env)>```
+>    is `false`, the expression
+>    ```stopped_as_optional.transform_sender(@[`set_value,`]{.add}@ sndr, env)``` is
+>    equivalent to ```@_`not-a-sender`_@()```; otherwise, it is equivalent to:
+>    [&hellip; as before &hellip;]{.blue}
 
 [Change [exec.stopped.err]{.sref} paragrpah 1-3 as follows:]{.ednote}
 


### PR DESCRIPTION
Paragraph 4 in [exec.stopped.opt] incorrectly uses `stopped_as_error_t` 
and `stopped_as_error.transform_sender` instead of `stopped_as_optional_t` 
and `stopped_as_optional.transform_sender`.

This appears to be a copy-paste error from the [exec.stopped.err] section.